### PR TITLE
Fixed the Sampling input so it works on OSX and with MovieRecorder.

### DIFF
--- a/source/FrameRecorder/Inputs/RenderTextureSampler/Editor/RenderTextureSamplerEditor.cs
+++ b/source/FrameRecorder/Inputs/RenderTextureSampler/Editor/RenderTextureSamplerEditor.cs
@@ -15,6 +15,7 @@ namespace UnityEditor.Recorder.Input
         SerializedProperty m_AspectRatio;
         SerializedProperty m_SuperSampling;
         SerializedProperty m_CameraTag;
+        SerializedProperty m_FlipFinalOutput;
 
         protected void OnEnable()
         {
@@ -28,6 +29,7 @@ namespace UnityEditor.Recorder.Input
             m_SuperSampling = pf.Find(w => w.m_SuperSampling);
             m_FinalSize = pf.Find(w => w.m_FinalSize);
             m_CameraTag = pf.Find(w => w.m_CameraTag);
+            m_FlipFinalOutput = pf.Find( w => w.m_FlipFinalOutput );
         }
 
 
@@ -80,7 +82,7 @@ namespace UnityEditor.Recorder.Input
                 using (new EditorGUI.DisabledScope(true))
                 {
                     EditorGUILayout.TextField("Color Space", (target as RenderTextureSamplerSettings).m_ColorSpace.ToString());
-                    EditorGUILayout.Toggle("Flip output", (target as RenderTextureSamplerSettings).m_FlipFinalOutput);
+                    EditorGUILayout.PropertyField(m_FlipFinalOutput, new GUIContent("Flip output"));
                 }
             }
 

--- a/source/FrameRecorder/Inputs/RenderTextureSampler/Engine/RenderTextureSampler.cs
+++ b/source/FrameRecorder/Inputs/RenderTextureSampler/Engine/RenderTextureSampler.cs
@@ -14,7 +14,7 @@ namespace UnityEngine.Recorder.Input
 
         RenderTexture m_renderRT;
         RenderTexture[] m_accumulateRTs = new RenderTexture[2];
-        int m_renderWidth, m_renderHeight, m_outputWidth, m_outputHeight;
+        int m_renderWidth, m_renderHeight;
 
         Material m_superMaterial;
         Material m_accumulateMaterial;
@@ -115,12 +115,12 @@ namespace UnityEngine.Recorder.Input
             var aspect = AspectRatioHelper.GetRealAR(rtsSettings.m_AspectRatio);
             m_renderHeight = (int)rtsSettings.m_RenderSize;
             m_renderWidth = Mathf.Min(16 * 1024, Mathf.RoundToInt(m_renderHeight * aspect));
-            m_outputHeight = (int)rtsSettings.m_FinalSize;
-            m_outputWidth = Mathf.Min(16 * 1024, Mathf.RoundToInt(m_outputHeight * aspect));
+            outputHeight = (int)rtsSettings.m_FinalSize;
+            outputWidth = Mathf.Min(16 * 1024, Mathf.RoundToInt(outputHeight * aspect));
             if (rtsSettings.m_ForceEvenSize)
             {
-                m_outputWidth = (m_outputWidth + 1) & ~1;
-                m_outputHeight = (m_outputHeight + 1) & ~1;
+                outputWidth = (outputWidth + 1) & ~1;
+                outputHeight = (outputHeight + 1) & ~1;
             }
 
             m_superMaterial = new Material(superShader);
@@ -140,7 +140,7 @@ namespace UnityEngine.Recorder.Input
                 m_accumulateRTs[i].wrapMode = TextureWrapMode.Clamp;
                 m_accumulateRTs[i].Create();
             }
-            var rt = new RenderTexture(m_outputWidth, m_outputHeight, 0, RenderTextureFormat.DefaultHDR, RenderTextureReadWrite.Linear);
+            var rt = new RenderTexture(outputWidth, outputHeight, 0, RenderTextureFormat.DefaultHDR, RenderTextureReadWrite.Linear);
             rt.Create();
             outputRT = rt;
             m_samples = new Vector2[(int)rtsSettings.m_SuperSampling];
@@ -312,7 +312,7 @@ namespace UnityEngine.Recorder.Input
             else
             {
                 // Ideally we would use a separable filter here, but we're massively bound by readback and disk anyway for hi-res.
-                m_superMaterial.SetVector("_Target_TexelSize", new Vector4(1f / m_outputWidth, 1f / m_outputHeight, m_outputWidth, m_outputHeight));
+                m_superMaterial.SetVector("_Target_TexelSize", new Vector4(1f / outputWidth, 1f / outputHeight, outputWidth, outputHeight));
                 m_superMaterial.SetFloat("_KernelCosPower", rtsSettings.m_SuperKernelPower);
                 m_superMaterial.SetFloat("_KernelScale", rtsSettings.m_SuperKernelScale);
                 m_superMaterial.SetFloat("_NormalizationFactor", 1.0f / (float)rtsSettings.m_SuperSampling);

--- a/source/FrameRecorder/Inputs/RenderTextureSampler/Shaders/BS4Accumulate.shader
+++ b/source/FrameRecorder/Inputs/RenderTextureSampler/Shaders/BS4Accumulate.shader
@@ -13,7 +13,8 @@ Properties {
 
 CGINCLUDE
 
-#pragma only_renderers d3d11 ps4 opengl
+// FIXME: Had to comment out to make it work on OSX. Needs to be revised.
+// #pragma only_renderers d3d11 ps4 opengl
 
 #include "UnityCG.cginc"
 

--- a/source/FrameRecorder/Inputs/RenderTextureSampler/Shaders/BS4SuperShader.shader
+++ b/source/FrameRecorder/Inputs/RenderTextureSampler/Shaders/BS4SuperShader.shader
@@ -7,7 +7,8 @@ Properties {
 
 CGINCLUDE
 
-#pragma only_renderers d3d11 ps4 opengl
+// FIXME: Had to comment out to make it work on OSX. Needs to be revised.
+// #pragma only_renderers d3d11 ps4 opengl
 
 #include "UnityCG.cginc"
 


### PR DESCRIPTION
RenderTextureSamplerEditor.cs
--------------------------------------------------------------------------------
    
The vertical flip control can now be manipulated during debug.
    
RenderTextureSampler.cs
--------------------------------------------------------------------------------
    
Now using the base class outputWidth and outputHeight so recorders can know in
advance what resolution the input intends to produce. Useful for the
MovieRecorder, which creates a movie file that needs this info upon creation.
    
BS4Accumulate.shader, BS4SuperShader.shader
--------------------------------------------------------------------------------
    
Disabled renderer restriction in the resampler input shaders. This was
preventing them from running on OSX.