### PR TITLE
Fixed compile error in Unity 2018.2b9

### DIFF
--- a/source/FrameRecorder/Inputs/Animation/Editor/AnimationInput.cs
+++ b/source/FrameRecorder/Inputs/Animation/Editor/AnimationInput.cs
@@ -25,7 +25,11 @@ namespace UnityEditor.Experimental.Recorder.Input
 #endif
             foreach (var binding in aniSettings.bindingType)
             {
-                m_gameObjectRecorder.BindComponent(srcGO, binding, aniSettings.recursive); 
+#if UNITY_2018_2_OR_NEWER
+                m_gameObjectRecorder.BindComponentsOfType(srcGO, binding, aniSettings.recursive);
+#else
+                m_gameObjectRecorder.BindComponent(srcGO, binding, aniSettings.recursive);
+#endif
             }
             m_time = session.recorderTime;
         }


### PR DESCRIPTION
GameObjectRecorder.BindComponent seems to obsolete in Unity 2018.2.
It is changed to BindComponentsOfType method.